### PR TITLE
Change logged precision of volume from 1 to 2

### DIFF
--- a/pychromecast/controllers/receiver.py
+++ b/pychromecast/controllers/receiver.py
@@ -183,7 +183,7 @@ class ReceiverController(BaseController):
 
         """
         volume = min(max(0, volume), 1)
-        self.logger.info("Receiver:setting volume to %.1f", volume)
+        self.logger.info("Receiver:setting volume to %.2f", volume)
         self.send_message({MESSAGE_TYPE: "SET_VOLUME", "volume": {"level": volume}})
         return volume
 


### PR DESCRIPTION
Before this change, updating volume from `0.80` to `0.89` would cause `pychromecast` to log the change as such:

    INFO:pychromecast.controllers:Receiver:setting volume to 0.8
    INFO:pychromecast.controllers:Receiver:setting volume to 0.8

After this change, logs accurately reflect volume changes:

    INFO:pychromecast.controllers:Receiver:setting volume to 0.80
    INFO:pychromecast.controllers:Receiver:setting volume to 0.89